### PR TITLE
#698/bank holidays

### DIFF
--- a/Parking.Data/BankHolidayRepository.cs
+++ b/Parking.Data/BankHolidayRepository.cs
@@ -12,6 +12,15 @@
             {
                 new BankHoliday(new LocalDate(2025, 12, 25)),
                 new BankHoliday(new LocalDate(2025, 12, 26)),
+                
+                new BankHoliday(new LocalDate(2026, 1, 1)),
+                new BankHoliday(new LocalDate(2026, 4, 3)),
+                new BankHoliday(new LocalDate(2026, 4, 6)),
+                new BankHoliday(new LocalDate(2026, 5, 4)),
+                new BankHoliday(new LocalDate(2026, 5, 25)),
+                new BankHoliday(new LocalDate(2026, 8, 31)),
+                new BankHoliday(new LocalDate(2026, 12, 25)),
+                new BankHoliday(new LocalDate(2026, 12, 28)),
             };
     }
 }

--- a/Parking.Data/BankHolidayRepository.cs
+++ b/Parking.Data/BankHolidayRepository.cs
@@ -10,31 +10,6 @@
         public IReadOnlyCollection<BankHoliday> GetBankHolidays() =>
             new[]
             {
-                new BankHoliday(new LocalDate(2023, 1, 2)),
-                new BankHoliday(new LocalDate(2023, 4, 7)),
-                new BankHoliday(new LocalDate(2023, 4, 10)),
-                new BankHoliday(new LocalDate(2023, 5, 1)),
-                new BankHoliday(new LocalDate(2023, 5, 8)),
-                new BankHoliday(new LocalDate(2023, 5, 29)),
-                new BankHoliday(new LocalDate(2023, 8, 28)),
-                new BankHoliday(new LocalDate(2023, 12, 25)),
-                new BankHoliday(new LocalDate(2023, 12, 26)),
-
-                new BankHoliday(new LocalDate(2024, 1, 1)),
-                new BankHoliday(new LocalDate(2024, 3, 29)),
-                new BankHoliday(new LocalDate(2024, 4, 1)),
-                new BankHoliday(new LocalDate(2024, 5, 6)),
-                new BankHoliday(new LocalDate(2024, 5, 27)),
-                new BankHoliday(new LocalDate(2024, 8, 26)),
-                new BankHoliday(new LocalDate(2024, 12, 25)),
-                new BankHoliday(new LocalDate(2024, 12, 26)),
-
-                new BankHoliday(new LocalDate(2025, 1, 1)),
-                new BankHoliday(new LocalDate(2025, 4, 18)),
-                new BankHoliday(new LocalDate(2025, 4, 21)),
-                new BankHoliday(new LocalDate(2025, 5, 5)),
-                new BankHoliday(new LocalDate(2025, 5, 26)),
-                new BankHoliday(new LocalDate(2025, 8, 25)),
                 new BankHoliday(new LocalDate(2025, 12, 25)),
                 new BankHoliday(new LocalDate(2025, 12, 26)),
             };


### PR DESCRIPTION
PR for #698.

I have added all the bank holidays for 2026, taken from https://www.gov.uk/bank-holidays.

I have also removed bank holidays that are in the past.

I haven't tested this out, as I don't have a dev environment set up on my PC. There are no spaces requested or allocated on 1 Jan 2026 (although I did have one accidentally requested, which I have since cancelled).